### PR TITLE
Fix S3 file-upload

### DIFF
--- a/dynamo/data/s3.py
+++ b/dynamo/data/s3.py
@@ -37,11 +37,7 @@ class S3Client():
     key : str
       The path and file name of the object in the S3 bucket.
     '''
-    return self.client.put_object(
-      Bucket = self.bucketname,
-      Key = key,
-      Body = file
-    )
+    self.client.upload_file(file, self.bucketname, key)
 
   def listParquet( self, prefix='/'):
     '''Lists the '.parquet' objects in a bucket.

--- a/test/test_s3.py
+++ b/test/test_s3.py
@@ -41,5 +41,5 @@ def test_getObject( bucket_name ):
   result = client.getObject( '/test.parquet' )
   assert 'Body' in result.keys()
   body_read = result['Body'].read()
-  assert body_read == bytes( 'test.parquet', 'utf-8' )
+  assert body_read == bytes( 'this is a test', 'utf-8' )
   os.remove( 'test.parquet' )


### PR DESCRIPTION
Fixes https://github.com/spulec/moto/issues/3573 :)

The `s3.put_object` method is useful when you have the raw content of what you want to upload:
```
s3.put_object(bucket, key, "this is the content of my file in parquet-format")
```
But the `upload_file` is more appropriate in this use case.

Note: The `test_processParquet` still fails, but due to an issue with ipify (Access restricted. Check credits balance or enter the correct API key.).
